### PR TITLE
Add test for tproxy's address field

### DIFF
--- a/nftables_test.go
+++ b/nftables_test.go
@@ -1206,6 +1206,74 @@ func TestTProxy(t *testing.T) {
 	}
 }
 
+func TestTProxyWithAddrField(t *testing.T) {
+	want := [][]byte{
+		// batch begin
+		[]byte("\x00\x00\x00\x0a"),
+		// nft add rule filter divert ip protocol tcp tproxy to 10.10.72.1:50080
+		[]byte("\x02\x00\x00\x00\x0b\x00\x01\x00\x66\x69\x6c\x74\x65\x72\x00\x00\x0b\x00\x02\x00\x64\x69\x76\x65\x72\x74\x00\x00\xe8\x00\x04\x80\x34\x00\x01\x80\x0c\x00\x01\x00\x70\x61\x79\x6c\x6f\x61\x64\x00\x24\x00\x02\x80\x08\x00\x01\x00\x00\x00\x00\x01\x08\x00\x02\x00\x00\x00\x00\x01\x08\x00\x03\x00\x00\x00\x00\x09\x08\x00\x04\x00\x00\x00\x00\x01\x2c\x00\x01\x80\x08\x00\x01\x00\x63\x6d\x70\x00\x20\x00\x02\x80\x08\x00\x01\x00\x00\x00\x00\x01\x08\x00\x02\x00\x00\x00\x00\x00\x0c\x00\x03\x80\x05\x00\x01\x00\x06\x00\x00\x00\x2c\x00\x01\x80\x0e\x00\x01\x00\x69\x6d\x6d\x65\x64\x69\x61\x74\x65\x00\x00\x00\x18\x00\x02\x80\x08\x00\x01\x00\x00\x00\x00\x01\x0c\x00\x02\x80\x08\x00\x01\x00\x0a\x0a\x48\x01\x2c\x00\x01\x80\x0e\x00\x01\x00\x69\x6d\x6d\x65\x64\x69\x61\x74\x65\x00\x00\x00\x18\x00\x02\x80\x08\x00\x01\x00\x00\x00\x00\x02\x0c\x00\x02\x80\x06\x00\x01\x00\xc3\xa0\x00\x00\x2c\x00\x01\x80\x0b\x00\x01\x00\x74\x70\x72\x6f\x78\x79\x00\x00\x1c\x00\x02\x80\x08\x00\x01\x00\x00\x00\x00\x02\x08\x00\x03\x00\x00\x00\x00\x02\x08\x00\x02\x00\x00\x00\x00\x01"),
+		// batch end
+		[]byte("\x00\x00\x00\x0a"),
+	}
+
+	c, err := nftables.New(nftables.WithTestDial(
+		func(req []netlink.Message) ([]netlink.Message, error) {
+			for idx, msg := range req {
+				b, err := msg.MarshalBinary()
+				if err != nil {
+					t.Fatal(err)
+				}
+				if len(b) < 16 {
+					continue
+				}
+				b = b[16:]
+				if len(want) == 0 {
+					t.Errorf("no want entry for message %d: %x", idx, b)
+					continue
+				}
+				if got, want := b, want[0]; !bytes.Equal(got, want) {
+					t.Errorf("message %d: %s", idx, linediff(nfdump(got), nfdump(want)))
+				}
+				want = want[1:]
+			}
+			return req, nil
+		}))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	c.AddRule(&nftables.Rule{
+		Table: &nftables.Table{Name: "filter", Family: nftables.TableFamilyIPv4},
+		Chain: &nftables.Chain{
+			Name:     "divert",
+			Type:     nftables.ChainTypeFilter,
+			Hooknum:  nftables.ChainHookPrerouting,
+			Priority: nftables.ChainPriorityRef(-150),
+		},
+		Exprs: []expr.Any{
+			//	[ payload load 1b @ network header + 9 => reg 1 ]
+			&expr.Payload{DestRegister: 1, Base: expr.PayloadBaseNetworkHeader, Offset: 9, Len: 1},
+			//	[ cmp eq reg 1 0x00000006 ]
+			&expr.Cmp{Op: expr.CmpOpEq, Register: 1, Data: []byte{unix.IPPROTO_TCP}},
+			//  [ immediate reg 1 0x01480a0a ]
+			&expr.Immediate{Register: 1, Data: []byte("\x0a\x0a\x48\x01")},
+			//	[ immediate reg 2 0x0000a0c3 ]
+			&expr.Immediate{Register: 2, Data: binaryutil.BigEndian.PutUint16(50080)},
+			//  [ tproxy ip addr reg 1 port reg 2 ]
+			&expr.TProxy{
+				Family:      byte(nftables.TableFamilyIPv4),
+				TableFamily: byte(nftables.TableFamilyIPv4),
+				RegAddr:     1,
+				RegPort:     2,
+			},
+		},
+	})
+
+	if err := c.Flush(); err != nil {
+		t.Fatal(err)
+	}
+}
+
 func TestCt(t *testing.T) {
 	want := [][]byte{
 		// batch begin


### PR DESCRIPTION
这个```[]byte want```里的内容不知道是怎么编码出来的，我试了一下utf-8，能看到```exprs```的一些助记符，我猜是其他文件里什么```marshal```方法生成的。
https://github.com/black-desk/nftables/blob/b696a8811f7c679aa58cabdd0f63a1f214e83c79/nftables_test.go#L1148-L1149
![tproxy](https://github.com/black-desk/nftables/assets/60538386/91c2e7fa-d142-4a91-852c-eda1a92a848b)
我尝试在网上寻找相关的信息，有一篇说是涉及BPF手册里的命令，但是我暂时还没去看。
现在是假定```tproxy.marshal```能正常工作，直接把```got```贴上去了（
应该没别的要改了？
